### PR TITLE
implement Anthropic Claude provider for complete three-provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # LLM Providers API Keys
 OPENAI_API_KEY="your_openai_api_key_here"
 GOOGLE_API_KEY="your_google_api_key_here"
+ANTHROPIC_API_KEY="your_anthropic_api_key_here"
 
 # Redis Configuration
 REDIS_HOST="redis"

--- a/app/providers/anthropic/__init__.py
+++ b/app/providers/anthropic/__init__.py
@@ -1,0 +1,1 @@
+# Anthropic provider package

--- a/app/providers/anthropic/provider.py
+++ b/app/providers/anthropic/provider.py
@@ -1,0 +1,147 @@
+import anthropic
+from typing import Dict, List, Any
+import time
+
+from app.models import ChatCompletionRequest
+from app.providers.base import LLMProvider
+
+
+class AnthropicProvider(LLMProvider):
+    """
+    Anthropic Claude provider implementation for chat completions.
+    
+    This class implements the LLMProvider interface specifically for Anthropic's
+    Claude API. It handles authentication, request/response translation, and
+    provides a unified OpenAI-compatible API interface.
+    """
+    
+    def __init__(self, api_key: str):
+        """
+        Initialize the Anthropic provider with an API key.
+        
+        Args:
+            api_key: The Anthropic API key for authentication.
+        """
+        self.api_key = api_key
+        self.client = anthropic.AsyncAnthropic(api_key=self.api_key)
+    
+    def _prepare_messages_for_anthropic(self, messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        """
+        Prepare messages for Anthropic API format.
+        
+        Anthropic's Messages API uses a similar format to OpenAI, but we need to
+        ensure proper structure and handle any system messages appropriately.
+        
+        Args:
+            messages: List of messages in OpenAI format.
+            
+        Returns:
+            List of messages formatted for Anthropic API.
+        """
+        anthropic_messages = []
+        
+        for message in messages:
+            role = message["role"]
+            content = message["content"]
+            
+            # Anthropic supports user, assistant, and system roles
+            # System messages can be passed directly
+            anthropic_messages.append({
+                "role": role,
+                "content": content
+            })
+        
+        return anthropic_messages
+    
+    def _translate_response_to_openai(self, anthropic_response, model_name: str) -> Dict[str, Any]:
+        """
+        Translate Anthropic response to OpenAI-compatible format.
+        
+        Args:
+            anthropic_response: The response from Anthropic Claude API.
+            model_name: The model name used for the request.
+            
+        Returns:
+            Dictionary in OpenAI response format.
+        """
+        # Extract the response text from Anthropic's content structure
+        response_text = ""
+        if anthropic_response.content and len(anthropic_response.content) > 0:
+            response_text = anthropic_response.content[0].text
+        
+        # Extract token usage information
+        input_tokens = anthropic_response.usage.input_tokens if anthropic_response.usage else 0
+        output_tokens = anthropic_response.usage.output_tokens if anthropic_response.usage else 0
+        total_tokens = input_tokens + output_tokens
+        
+        # Create OpenAI-compatible response structure
+        openai_response = {
+            "id": f"chatcmpl-{int(time.time())}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": response_text
+                    },
+                    "finish_reason": anthropic_response.stop_reason or "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": input_tokens,
+                "completion_tokens": output_tokens,
+                "total_tokens": total_tokens
+            }
+        }
+        
+        return openai_response
+    
+    async def create_completion(self, request: ChatCompletionRequest) -> dict:
+        """
+        Create a chat completion using Anthropic Claude API.
+        
+        This method translates the OpenAI-compatible request to Anthropic's format,
+        calls the Claude API, and translates the response back to OpenAI format.
+        
+        Args:
+            request: The validated chat completion request containing model, messages, and options.
+            
+        Returns:
+            dict: The JSON response in OpenAI-compatible format.
+            
+        Raises:
+            Exception: If the Anthropic API call fails or returns an error.
+        """
+        try:
+            # Prepare messages for Anthropic API
+            anthropic_messages = self._prepare_messages_for_anthropic(request.messages)
+            
+            # Ensure max_tokens is provided (required by Anthropic)
+            max_tokens = getattr(request, 'max_tokens', 4096)
+            if max_tokens is None:
+                max_tokens = 4096
+            
+            # Prepare other parameters
+            temperature = getattr(request, 'temperature', 0.7)
+            if temperature is None:
+                temperature = 0.7
+            
+            # Call Anthropic Claude API
+            response = await self.client.messages.create(
+                model=request.model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=anthropic_messages
+            )
+            
+            # Translate response back to OpenAI format
+            openai_response = self._translate_response_to_openai(response, request.model)
+            
+            return openai_response
+            
+        except Exception as e:
+            # Re-raise with more context
+            raise Exception(f"Anthropic Claude API error: {str(e)}")

--- a/app/services.py
+++ b/app/services.py
@@ -2,6 +2,7 @@ from app.models import ChatCompletionRequest
 from app.providers.base import LLMProvider
 from app.providers.openai.provider import OpenAIProvider
 from app.providers.google.provider import GoogleProvider
+from app.providers.anthropic.provider import AnthropicProvider
 from app.cache import generate_cache_key, get_from_cache, set_to_cache
 from app.config import config
 
@@ -32,9 +33,11 @@ def get_provider(model_name: str) -> LLMProvider:
                 return OpenAIProvider(api_key=provider_config.api_key)
             elif provider_config.name == "google":
                 return GoogleProvider(api_key=provider_config.api_key)
+            elif provider_config.name == "anthropic":
+                return AnthropicProvider(api_key=provider_config.api_key)
             # Future providers can be added here:
-            # elif provider_config.name == "anthropic":
-            #     return AnthropicProvider(api_key=provider_config.api_key)
+            # elif provider_config.name == "cohere":
+            #     return CohereProvider(api_key=provider_config.api_key)
     
     # No provider found for the model
     raise ValueError(f"No provider found for model: {model_name}")

--- a/config.yaml
+++ b/config.yaml
@@ -2,9 +2,7 @@
 
 providers:
   - name: "openai"
-    # This points to the environment variable containing the actual API key
     api_key_env: "OPENAI_API_KEY"
-    # List of models handled by this provider
     models:
       - "gpt-4o"
       - "gpt-4o-mini"
@@ -16,3 +14,10 @@ providers:
       - "gemini-2.5-flash"
       - "gemini-2.5-flash-lite-preview-06-17"
       - "gemini-2.5-pro"
+
+  - name: "anthropic"
+    api_key_env: "ANTHROPIC_API_KEY"
+    models:
+      - "claude-opus-4-20250514"
+      - "claude-sonnet-4-20250514"
+      - "claude-3-7-sonnet-latest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ presidio-anonymizer
 spacy
 starlette-prometheus
 PyYAML
-google-generativeai 
+google-generativeai
+anthropic 


### PR DESCRIPTION
- Add anthropic library dependency for Claude API integration
- Update .env.example with ANTHROPIC_API_KEY configuration
- Extend config.yaml with Anthropic provider and Claude models
- Create AnthropicProvider class with request/response translation
- Implement native Anthropic Messages API integration
- Add accurate token usage tracking from Claude API responses
- Update routing factory to support Anthropic provider selection
- Complete three-provider architecture: OpenAI, Google, Anthropic

The gateway now supports 9 models across 3 major LLM providers:
- OpenAI: GPT-4o, GPT-4o-mini, GPT-3.5-turbo
- Google: Gemini 2.5 Flash/Pro variants
- Anthropic: Claude Opus 4, Sonnet 4, 3.7 Sonnet Latest

All providers maintain unified OpenAI-compatible API interface with intelligent routing based on model names.