### PR TITLE
fix GitHub Pages deployment permissions and workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     
     steps:
     - uses: actions/checkout@v4
@@ -202,9 +206,14 @@ jobs:
       run: |
         mkdocs build --strict
         
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
-      if: github.ref == 'refs/heads/main'
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+      
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./site
+        path: ./site
+        
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Updated docs job with proper permissions (pages: write, id-token: write)
- Replaced peaceiris/actions-gh-pages with official GitHub Pages actions
- Added configure-pages, upload-pages-artifact, and deploy-pages actions
- This should resolve the 403 permission error during Pages deployment