### PR TITLE
fix Docker container startup by adding config.yaml to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN python -m spacy download en_core_web_lg
 # Copy the application code
 COPY ./app /code/app
 COPY create_key.py /code/create_key.py
+COPY config.yaml /code/config.yaml
 
 # Command to run the application
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"] 


### PR DESCRIPTION
- Added COPY config.yaml /code/config.yaml to Dockerfile
- This resolves the "Configuration file not found at config.yaml" error
- Container was failing to start because config.yaml wasn't included in the image
