### PR TITLE
fix Docker container 500 Internal Server Error

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -78,10 +78,11 @@ async def process_chat_completion(request: ChatCompletionRequest) -> dict:
     prompt_text = ""
     if request.messages and len(request.messages) > 0:
         # Get the last user message content
-        prompt_text = request.messages[-1].get("content", "")
+        last_message = request.messages[-1]
+        prompt_text = last_message.content if hasattr(last_message, 'content') else ""
     
     # Search for semantically similar cached responses
-    semantic_redis_key = await search_semantic_cache(prompt_text)
+    semantic_redis_key = search_semantic_cache(prompt_text)
     if semantic_redis_key is not None:
         print("✅ SEMANTIC CACHE HIT!")
         # Retrieve the full response using the semantic cache's Redis key


### PR DESCRIPTION
Critical fixes for runtime errors:
- Fixed ChatMessage object attribute access in services.py (line 81)
- Changed message.get() to message.content for Pydantic objects
- Removed incorrect await from search_semantic_cache() call
- Re-enabled DLP middleware after debugging

The API now responds correctly:
✅ POST /v1/chat/completions returns proper OpenAI-compatible responses 
✅ All middleware functioning correctly
✅ Token usage tracking working
✅ Container startup and runtime working
