### PR TITLE
add complete data persistence for Grafana and Prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
     depends_on:
       - gateway
     networks:
@@ -41,6 +42,9 @@ services:
       - GF_INSTALL_PLUGINS=
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards  
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
     depends_on:
       - prometheus
     networks:
@@ -48,6 +52,7 @@ services:
 
 volumes:
   grafana_data:
+  prometheus_data:
 
 networks:
   shared-app-network:

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    uid: prometheus-uid
+    jsonData:
+      timeInterval: 5s
+      queryTimeout: 60s
+      httpMethod: GET


### PR DESCRIPTION
- Add persistent volumes for grafana_data and prometheus_data
- Create Grafana provisioning configuration for automatic Prometheus datasource
- Add dashboard provisioning setup with proper directory structure
- Eliminate need to manually configure Grafana-Prometheus connection
- Data now persists across container restarts (API keys, metrics, dashboards)
- Grafana automatically connects to Prometheus on startup

Key files:
- grafana/provisioning/datasources/prometheus.yml: Auto-configures Prometheus datasource
- grafana/provisioning/dashboards/dashboard.yml: Dashboard provisioning config
- Updated docker-compose.yml with persistent volumes and volume mounts
